### PR TITLE
Few bug fixes for OS X.

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -18,10 +18,15 @@ plan (int tests) {
 
 static char *
 vstrdupf (const char *fmt, va_list args) {
-    char *str;
-    int size = vsnprintf(NULL, 0, fmt, args) + 2;
+    char *str = "";
+    va_list args2;
+    va_copy(args2, args);
+    if(!fmt)
+      fmt = "";
+    int size = vsnprintf(NULL, 0, fmt, args2) + 2;
     str = malloc(size);
     vsprintf(str, fmt, args);
+    va_end(args2);
     return str;
 }
 


### PR DESCRIPTION
libtap wasn't building on OS X, and was segfaulting after fixing (a)

a) a bug with the naming of MAP_ANONYMOUS
b) vstrdupf was segfaulting when fmt was NULL
c) vstrdupf was not copying it's args argument, and that was causing segfaults, also.
