### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: erlang # no C/shell language support; use least-loaded worker(s)
+
+before_install: sudo apt-get install -y libtest-differences-perl
+
+install: make install
+
+script: make test
+
+after_script: make uninstall


### PR DESCRIPTION
This commit adds support for Travis CI (http://about.travis-ci.org/docs/).

All you have to do is to enable the Travis service hook for libtap. Afterwards, Travis will compile, install, and test libtap for each new commit pushed to GitHub, giving us all the benefits of continuous integration.

Here's how the CI results look like: http://travis-ci.org/#!/mlafeldt/libtap/builds/1824528

(Travis currently runs Ubuntu 12.04.)
