### PR TITLE
Ignore build products for Unix-like systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,14 @@
+*.a
+*.o
 *.sw?
 
+# compiled tests
+/t/cmpok
+/t/diesok
+/t/is
+/t/like
+/t/notediag
+/t/simple
+/t/skip
+/t/synopsis
+/t/todo


### PR DESCRIPTION
Adds some more entries to the `.gitignore` file, so Git reports a clean state even after building libtap via `make`.

(Does not ignore Windows build products though.)
