### PR TITLE
Let Travis test libtap against gcc and clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
-language: erlang # no C/shell language support; use least-loaded worker(s)
+language: c
+
+compiler:
+  - gcc
+  - clang
 
 before_install: sudo apt-get install -y libtest-differences-perl
 
-install: make install
+install: make CC=$CC install
 
-script: make test
+script: make CC=$CC test
 
 after_script: make uninstall


### PR DESCRIPTION
As Travis now officially supports C, test libtap against gcc and clang.

Results:

gcc - http://travis-ci.org/#!/mlafeldt/libtap/jobs/1960553
clang - http://travis-ci.org/#!/mlafeldt/libtap/jobs/1960554
