### PR TITLE
Define _BSD_SOURCE to 1

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -4,6 +4,8 @@ Copyright 2012 Jake Gelbman <gelbman@gmail.com>
 This file is licensed under the GPLv2
 */
 
+#define _BSD_SOURCE 1
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdarg.h>


### PR DESCRIPTION
This appears to be needed to get the MAP_ANONYMOUS macro when compiling with --std=c99
