### PR TITLE
Add AUTO_PLAN to determine number of tests in file

### DIFF
--- a/t/auto_plan.c
+++ b/t/auto_plan.c
@@ -1,0 +1,20 @@
+#define USE_AUTO_PLAN
+#include "tap.h"
+
+void test_everything () {
+    char buf1[4] = { 0, 1, 2, 3 };
+    char buf2[4] = { 0, 1, 2, 3 };
+
+    cmp_ok(1, "==", 1, "cmp_ok");
+    ok(1, "ok");
+    is("abc", "abc", "is");
+    isnt("abc", "foo", "isnt");
+    cmp_mem(buf1, buf2, sizeof(buf1), "cmp_mem");
+    like("fnord", "f(yes|no)r*[a-f]$", "like");
+}
+
+int main () {
+    plan(AUTO_PLAN);
+    test_everything();
+    done_testing();
+}

--- a/t/auto_plan.expected
+++ b/t/auto_plan.expected
@@ -1,0 +1,7 @@
+1..6
+ok 1 - cmp_ok
+ok 2 - ok
+ok 3 - is
+ok 4 - isnt
+ok 5 - cmp_mem
+ok 6 - like

--- a/tap.h
+++ b/tap.h
@@ -43,13 +43,23 @@ void    tap_skip        (int n, const char *fmt, ...);
 void    tap_todo        (int ignore, const char *fmt, ...);
 void    tap_end_todo    (void);
 
+#ifdef USE_AUTO_PLAN
+#define THROWAWAY_(...)
+#define THROWAWAY(...) THROWAWAY_(__VA_ARGS__)
+#define AUTO_PLAN __COUNTER__
+#define AUTO_PLAN_INC() THROWAWAY(__COUNTER__)
+#else /* !USE_AUTO_PLAN */
+#define AUTO_PLAN_INC()
+#endif /* /USE_AUTO_PLAN */
+
+
 #define NO_PLAN          -1
 #define SKIP_ALL         -2
-#define ok(...)          ok_at_loc(__FILE__, __LINE__, (int) __VA_ARGS__, NULL)
-#define is(...)          is_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
-#define isnt(...)        isnt_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
-#define cmp_ok(...)      cmp_ok_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
-#define cmp_mem(...)     cmp_mem_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL)
+#define ok(...)          ok_at_loc(__FILE__, __LINE__, (int) __VA_ARGS__, NULL) AUTO_PLAN_INC()
+#define is(...)          is_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
+#define isnt(...)        isnt_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
+#define cmp_ok(...)      cmp_ok_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
+#define cmp_mem(...)     cmp_mem_at_loc(__FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
 #define plan(...)        tap_plan(__VA_ARGS__, NULL)
 #define done_testing()   return exit_status()
 #define BAIL_OUT(...)    bail_out(0, "" __VA_ARGS__, NULL)
@@ -71,8 +81,8 @@ void    tap_end_todo    (void);
 #define dies_ok_common(...) \
                          tap_skip(1, "Death detection is not supported on Windows")
 #else
-#define like(...)        like_at_loc(1, __FILE__, __LINE__, __VA_ARGS__, NULL)
-#define unlike(...)      like_at_loc(0, __FILE__, __LINE__, __VA_ARGS__, NULL)
+#define like(...)        like_at_loc(1, __FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
+#define unlike(...)      like_at_loc(0, __FILE__, __LINE__, __VA_ARGS__, NULL) AUTO_PLAN_INC()
 int     like_at_loc     (int for_match, const char *file, int line,
                          const char *got, const char *expected,
                          const char *fmt, ...);


### PR DESCRIPTION
# Motivation

A lot of my test files take the form of:

```c

void test_literals(void) {
    cmp_ok(3, "==", 3, "should find that 3 equals 3");
}

void test_arithmetic(void) {
    cmp_ok(1+1, "==", 2, "should find that 1+1 equals 2");
    cmp_ok(2*2, "==", 4, "should find that 2*2 equals 4");
}

int main(int argc, char **argv) {
    plan(NO_PLAN);
    test_literals();
    test_arithmetic();
    done_testing();
}
```

However, the problem with this is that it doesn't know the number of tests in advance. The easy workaround is to run it once, determine the number of tests, and then modify the `plan(NO_PLAN)` like to use that number, but this is a little awkward, especially when the compiler could do the counting for us.

# Implementation

`AUTO_PLAN` is an implementation of this idea of making the compiler count for us. It uses the special preprocessor variable `__COUNTER__` to count all of the lines that could produce an output line. The way to use this feature is:

```c

void test_literals(void) {
    cmp_ok(3, "==", 3, "should find that 3 equals 3");
}

void test_arithmetic(void) {
    cmp_ok(1+1, "==", 2, "should find that 1+1 equals 2");
    cmp_ok(2*2, "==", 4, "should find that 2*2 equals 4");
}

int main(int argc, char **argv) {
    plan(AUTO_PLAN);
    test_literals();
    test_arithmetic();
    done_testing();
}
```

The compiler will automatically determine that it should plan for 3 test cases (the 3 `cmp_ok` lines) and rewrite the `plan(AUTO_PLAN)` as `plan(3)`. I decided to hide this feature behind an `#ifdef
USE_AUTO_PLAN` because there is a possibility that someone's code already uses the `__COUNTER__` variable.

One of the major limitations of this feature is that you can't split your tests up into multiple files and expect it to work, because the `__COUNTER__` variable gets reset for each file. We could work around this problem by using Boost, but that's too large of a dependency for a simple library like this one.

Another limitation is that it will get the wrong count if you use `pass()` and `fail()` separately. This is because they each use `ok()` internally, but each `ok()` increases the number of tests, so if you had
a construct like:

```c
void test_pass_fail(void) {
    if (some_complicated_function()) {
        pass("Hooray");
    } else {
        fail("Boo");
    }
}
```

then this will be incorrectly counted as 2 tests instead of 1 (the `pass()` gets transformed into `ok(1, "", "Hooray")` and similarly for `fail()`). A workaround would be:

```c
void test_pass_fail(void) {
    int rv;

    rv = some_complicated_function();
    cmp_ok(rv, "==", 0, "should do something correctly");
}
```

which will be correctly counted as 1 test.

----

Let me know if you have any questions or concerns with this feature.