### PR TITLE
Only define define MAP_ANONYMOUS when necessary

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -298,8 +298,12 @@ tap_end_todo () {
 #include <sys/param.h>
 #include <regex.h>
 
-#if defined __APPLE__ || defined BSD
+#ifndef MAP_ANONYMOUS
+#ifdef MAP_ANON
 #define MAP_ANONYMOUS MAP_ANON
+#else
+#error "System does not support mapping anonymous pages"
+#endif
 #endif
 
 /* Create a shared memory int to keep track of whether a piece of code executed


### PR DESCRIPTION
On NetBSD ``MAP_ANONYMOUS`` is already defined and libtap fails to build with:

```
$ uname -v
NetBSD 7.1.2 (GENERIC.201803151611Z)

$ gmake
cc -Wall -I. -fPIC   -c tap.c  -o tap.o
tap.c:302:0: warning: "MAP_ANONYMOUS" redefined [enabled by default]
 #define MAP_ANONYMOUS MAP_ANON
 ^
In file included from tap.c:297:0:
/usr/include/sys/mman.h:97:0: note: this is the location of the previous definition
 #define MAP_ANONYMOUS 0x1000 /* allocated from memory, swap space */
 ^
tap.c: In function 'tap_test_died':
tap.c:302:23: error: 'MAP_ANONYMOUS' undeclared (first use in this function)
 #define MAP_ANONYMOUS MAP_ANON
                       ^
tap.c:313:39: note: in expansion of macro 'MAP_ANONYMOUS'
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
                                       ^
tap.c:302:23: note: each undeclared identifier is reported only once for each function it appears in
 #define MAP_ANONYMOUS MAP_ANON
                       ^
tap.c:313:39: note: in expansion of macro 'MAP_ANONYMOUS'
                          MAP_SHARED | MAP_ANONYMOUS, -1, 0);
                                       ^
Makefile:16: recipe for target 'tap.o' failed
gmake: *** [tap.o] Error 1
```

I started out with this approach:
```
#ifndef MAP_ANONYMOUS && defined MAP_ANON
#define MAP_ANONYMOUS MAP_ANON
#endif
```

but instead decided to heavily borrow an approach from [libressl-portable](https://github.com/libressl-portable/portable/commit/af705b3f7d92d6f2d08d6df00c54504ece53e4f1).