### PR TITLE
Fix bug which prevents builds for Windows targets

### DIFF
--- a/tap.h
+++ b/tap.h
@@ -67,7 +67,7 @@ void    tap_end_todo    (void);
 
 #ifdef _WIN32
 #define like(...)        tap_skip(1, "like is not implemented on Windows")
-#define unlike           tap_skip(1, "unlike is not implemented on Windows")
+#define unlike(...)      tap_skip(1, "unlike is not implemented on Windows")
 #define dies_ok_common(...) \
                          tap_skip(1, "Death detection is not supported on Windows")
 #else


### PR DESCRIPTION
unlike is replaced with a skip macro on Windows.  The macro definition is missing needed parenthesis and that results in Windows builds failing.  This PR corrects the macro.