### PR TITLE
Make division by zero test fail

### DIFF
--- a/t/diesok.c
+++ b/t/diesok.c
@@ -3,7 +3,7 @@
 int main () {
     plan(5);
     ok(1, "sanity");
-    dies_ok({int x = 0; x = x/x;}, "can't divide by zero");
+    dies_ok({int x = 0; x = 1/x;}, "can't divide by zero");
     lives_ok({int x = 3; x = x/7;}, "this is a perfectly fine statement");
     dies_ok({abort();}, "abort kills the program");
     dies_ok(


### PR DESCRIPTION
I am guessing on my environment, `x = x/x` gets optimized by the compiler into `x = 1`, because the test didn't die; now it does.