### PR TITLE
Include additional headers to fix compilation on macOS

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -10,6 +10,8 @@ This file is licensed under the LGPL
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
+#include <sys/types.h>
+#include <sys/mman.h>
 #include "tap.h"
 
 static int expected_tests = NO_PLAN;


### PR DESCRIPTION
This is because compilation on macOS 10.15 is failing due to MAP_ANON
not being defined.