### PR TITLE
Forcibly disable optimization on tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ tests: $(TESTS)
 $(TESTS): %: %.o libtap.a
 
 $(patsubst %, %.o, $(TESTS)): %.o: %.c tap.h
+	$(CC) $(CFLAGS) -O0 $(CPPFLAGS) $(TARGET_ARCH) -c $(filter %.c, $^) $(LDLIBS) -o $@
 
 clean:
 	rm -rf *.o t/*.o tap.pc libtap.a libtap.so $(TESTS)


### PR DESCRIPTION
I ran into the issue of GCC optimization causing a test failure in `t/diesok.c` at the division-by-zero test, even after rebasing our internal package's source against 56e3123 (internal case CPANEL-41315). At first, I resorted to inline assembly, and I also considered using a pragma or function attributes to limit the disabling of optimization to just the code or file of that test, but this seemed like the most generic well-supported solution.