### PR TITLE
fix dropped const qualifier

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -198,8 +198,8 @@ cmp_mem_at_loc (const char *file, int line, const void *got,
     va_end(args);
     if (diff == 1) {
         diag("    Difference starts at offset %d", offset);
-        diag("         got: 0x%02x", ((unsigned char *)got)[offset]);
-        diag("    expected: 0x%02x", ((unsigned char *)expected)[offset]);
+        diag("         got: 0x%02x", ((const unsigned char *)got)[offset]);
+        diag("    expected: 0x%02x", ((const unsigned char *)expected)[offset]);
     }
     else if (diff == 2) {
         diag("         got: %s", got ? "not NULL" : "NULL");


### PR DESCRIPTION
fixes t/tap.c:201:56: fatal error: cast from 'const void *' to 'unsigned char *' drops const qualifier [-Wcast-qual]