### PR TITLE
Fix compilation on Windows

### DIFF
--- a/tap.c
+++ b/tap.c
@@ -14,6 +14,20 @@ This file is licensed under the LGPL
 #include <sys/mman.h>
 #include "tap.h"
 
+#ifndef _WIN32
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <regex.h>
+
+#ifndef MAP_ANONYMOUS
+#ifdef MAP_ANON
+#define MAP_ANONYMOUS MAP_ANON
+#else
+#error "System does not support mapping anonymous pages"
+#endif
+#endif
+#endif
+
 static int expected_tests = NO_PLAN;
 static int failed_tests;
 static int current_test;
@@ -300,18 +314,6 @@ tap_end_todo () {
 }
 
 #ifndef _WIN32
-#include <sys/mman.h>
-#include <sys/param.h>
-#include <regex.h>
-
-#ifndef MAP_ANONYMOUS
-#ifdef MAP_ANON
-#define MAP_ANONYMOUS MAP_ANON
-#else
-#error "System does not support mapping anonymous pages"
-#endif
-#endif
-
 /* Create a shared memory int to keep track of whether a piece of code executed
 dies. to be used in the dies_ok and lives_ok macros.  */
 int

--- a/tap.c
+++ b/tap.c
@@ -10,11 +10,10 @@ This file is licensed under the LGPL
 #include <stdlib.h>
 #include <stdarg.h>
 #include <string.h>
-#include <sys/types.h>
-#include <sys/mman.h>
 #include "tap.h"
 
 #ifndef _WIN32
+#include <sys/types.h>
 #include <sys/mman.h>
 #include <sys/param.h>
 #include <regex.h>


### PR DESCRIPTION
It turns out I accidentally broke compilation on Windows in #37. Sorry about that. This seems to fix it.

I tested it by updating to my branch's version in the libmaxminddb repo, which has tests that run on Linux, macOS, and Windows. The test checks show beside the commit [here](https://github.com/maxmind/libmaxminddb/compare/horgh/testing?expand=1).